### PR TITLE
Fix template-janitor.yml to be able to push

### DIFF
--- a/.github/workflows/template-janitor.yml
+++ b/.github/workflows/template-janitor.yml
@@ -7,10 +7,11 @@ on:
   release:
     types: [published]
   push:
-    tags:
     branches:
       - main
       - develop
+permissions:
+  contents: write
 
 env:
   TEMPLATES_PATH: ".github/template"


### PR DESCRIPTION
Fixes #38, fixes #39.

Note that for now the action will be run twice because of this bug : https://github.com/actions/runner/issues/2550

This means the second run will fail since it will try to push without pulling, but it will probably be fixed on github side.