### PR TITLE
Goal:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ endif()
 # when compiling with PCH enabled
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(myproject_variables.cmake)
+
 # Set the project name and language
 project(
   myproject
@@ -92,7 +94,8 @@ if(MSVC)
 endif()
 
 # set the startup project for the "play" button in MSVC
-set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT intro)
+#set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT intro)
+set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT ${DEFAULT_EXEC})
 
 if(CMAKE_SKIP_INSTALL_RULES)
   return()
@@ -104,7 +107,7 @@ include(cmake/PackageProject.cmake)
 # we know we want to ship
 myproject_package_project(
   TARGETS
-  intro
+  ${PROJ_EXEC1}
   myproject_options
   myproject_warnings
   # FIXME: this does not work! CK

--- a/myproject_variables.cmake
+++ b/myproject_variables.cmake
@@ -1,0 +1,11 @@
+set(PROJ_EXEC1 "intro")
+
+#directories under src that will be added as subdirectories to the project
+set(MY_PROJECT_SUBDIRECTORIES "ftxui_sample;sample_library")
+
+set(DEFAULT_EXEC ${PROJ_EXEC1} CACHE STRING "Default executable to build")
+
+#set(MY_PROJECT_TARGETS "${PROJ_EXEC1} ${SERVER_APP}")
+set(MY_PROJECT_TARGETS "${PROJ_EXEC1}")
+
+MESSAGE(STATUS "MY PROJECT TARGETS = ${MY_PROJECT_TARGETS}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_subdirectory(sample_library)
-add_subdirectory(ftxui_sample)
+foreach(d ${MY_PROJECT_SUBDIRECTORIES})
+   MESSAGE(STATUS "Adding subdirectory: ${d}")
+   add_subdirectory(${d})
+endforeach()


### PR DESCRIPTION
  Allow someone that uses the cmake_template to have a single varaible file to add
  * executables
  * add sub directories
  * set the default vscode project

Thereby not needing to change the cmake files provided by the template. I'm sure there is more to do here but its a start.