### PR TITLE
update msvc ASAN support and copy required install dlls

### DIFF
--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -9,7 +9,7 @@ function(myproject_setup_dependencies)
   # already been provided to us by a parent project
 
   if(NOT TARGET fmtlib::fmtlib)
-    cpmaddpackage("gh:fmtlib/fmt#9.1.0")
+    cpmaddpackage("gh:fmtlib/fmt#10.2.1")
   endif()
 
   if(NOT TARGET spdlog::spdlog)
@@ -17,7 +17,7 @@ function(myproject_setup_dependencies)
       NAME
       spdlog
       VERSION
-      1.11.0
+      1.13.0
       GITHUB_REPOSITORY
       "gabime/spdlog"
       OPTIONS

--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -9,7 +9,7 @@ function(myproject_setup_dependencies)
   # already been provided to us by a parent project
 
   if(NOT TARGET fmtlib::fmtlib)
-    cpmaddpackage("gh:fmtlib/fmt#10.2.1")
+    cpmaddpackage("gh:fmtlib/fmt#9.1.0")
   endif()
 
   if(NOT TARGET spdlog::spdlog)
@@ -17,7 +17,7 @@ function(myproject_setup_dependencies)
       NAME
       spdlog
       VERSION
-      1.13.0
+      1.11.0
       GITHUB_REPOSITORY
       "gabime/spdlog"
       OPTIONS

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -45,7 +45,11 @@ function(
     endif()
   elseif(MSVC)
     if(${ENABLE_SANITIZER_ADDRESS})
-      list(APPEND SANITIZERS "address")
+       if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+          message(WARNING "MSVC only supports address sanitizer in release builds")
+       else()
+          list(APPEND SANITIZERS "address")
+       endif()
     endif()
     if(${ENABLE_SANITIZER_LEAK}
        OR ${ENABLE_SANITIZER_UNDEFINED_BEHAVIOR}

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -49,6 +49,15 @@ function(
           message(WARNING "MSVC only supports address sanitizer in release builds")
        else()
           list(APPEND SANITIZERS "address")
+          cmake_path(GET CMAKE_CXX_COMPILER PARENT_PATH MSVC_TOOLS_DIR)
+          install(
+              FILES 
+                  "${MSVC_TOOLS_DIR}/clang_rt.asan_dbg_dynamic-x86_64.dll"
+                  "${MSVC_TOOLS_DIR}/clang_rt.asan_dbg_dynamic-x86_64.pdb"
+                  "${MSVC_TOOLS_DIR}/clang_rt.asan_dynamic-x86_64.dll"
+                  "${MSVC_TOOLS_DIR}/clang_rt.asan_dynamic-x86_64.pdb"
+              TYPE BIN
+          )
        endif()
     endif()
     if(${ENABLE_SANITIZER_LEAK}

--- a/src/ftxui_sample/CMakeLists.txt
+++ b/src/ftxui_sample/CMakeLists.txt
@@ -18,14 +18,3 @@ target_link_system_libraries(
 
 target_include_directories(intro PRIVATE "${CMAKE_BINARY_DIR}/configured_files/include")
 
-if(MSVC AND myproject_ENABLE_SANITIZER_ADDRESS)
-    cmake_path(GET CMAKE_CXX_COMPILER PARENT_PATH MSVC_TOOLS_DIR)
-    install(
-        FILES 
-            "${MSVC_TOOLS_DIR}/clang_rt.asan_dbg_dynamic-x86_64.dll"
-            "${MSVC_TOOLS_DIR}/clang_rt.asan_dbg_dynamic-x86_64.pdb"
-            "${MSVC_TOOLS_DIR}/clang_rt.asan_dynamic-x86_64.dll"
-            "${MSVC_TOOLS_DIR}/clang_rt.asan_dynamic-x86_64.pdb"
-        TYPE BIN
-    )
-endif()

--- a/src/ftxui_sample/CMakeLists.txt
+++ b/src/ftxui_sample/CMakeLists.txt
@@ -17,3 +17,15 @@ target_link_system_libraries(
           ftxui::component)
 
 target_include_directories(intro PRIVATE "${CMAKE_BINARY_DIR}/configured_files/include")
+
+if(MSVC AND myproject_ENABLE_SANITIZER_ADDRESS)
+    cmake_path(GET CMAKE_CXX_COMPILER PARENT_PATH MSVC_TOOLS_DIR)
+    install(
+        FILES 
+            "${MSVC_TOOLS_DIR}/clang_rt.asan_dbg_dynamic-x86_64.dll"
+            "${MSVC_TOOLS_DIR}/clang_rt.asan_dbg_dynamic-x86_64.pdb"
+            "${MSVC_TOOLS_DIR}/clang_rt.asan_dynamic-x86_64.dll"
+            "${MSVC_TOOLS_DIR}/clang_rt.asan_dynamic-x86_64.pdb"
+        TYPE BIN
+    )
+endif()


### PR DESCRIPTION
MSVC does not allow the use of ASAN on debug builds, so modified sanitizers.cmake to reflect that.
MSVC requires the ASAN dlls to run, so I put an install for them into sanitizers.cmake.

The package updates are unrelated, but I was getting a lot of deprication warnings (promoted to errors) in msvc debug builds.  Bumping the version to the latest resolved them.
