### PR TITLE
Enforce the use of `override`

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -56,6 +56,7 @@ function(
         -Wdouble-promotion # warn if float is implicit promoted to double
         -Wformat=2 # warn on security issues around functions that format output (ie printf)
         -Wimplicit-fallthrough # warn on statements that fallthrough without an explicit annotation
+        -Wsuggest-override # warn if an overridden member function is not marked 'override' or 'final'
     )
   endif()
 

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -56,7 +56,6 @@ function(
         -Wdouble-promotion # warn if float is implicit promoted to double
         -Wformat=2 # warn on security issues around functions that format output (ie printf)
         -Wimplicit-fallthrough # warn on statements that fallthrough without an explicit annotation
-        -Wsuggest-override # warn if an overridden member function is not marked 'override' or 'final'
     )
   endif()
 
@@ -68,6 +67,7 @@ function(
         -Wduplicated-branches # warn if if / else branches have duplicated code
         -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
         -Wuseless-cast # warn if you perform a cast to the same type
+        -Wsuggest-override # warn if an overridden member function is not marked 'override' or 'final'
     )
   endif()
 


### PR DESCRIPTION
`-Wsuggest-override` has been available on GCC since 5.1. It warns if a member function overrides a base class function, but is not marked `override` (or `final` since GCC 9.2).

It appears that Visual Studio [has a similar warning](https://learn.microsoft.com/en-us/cpp/code-quality/c26433?view=msvc-170), but not being a Visual Studio user, I can't figure out how to enable it.

Since the template says it [should work with Clang 6](https://github.com/cpp-best-practices/cmake_template/blob/main/README_dependencies.md#necessary-dependencies), and this warning was introduced in Clang in version 11.0.0, I only enabled it for GCC.

* [cpp core guidelines on override](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final)
* [cpp best practices on override](https://github.com/cpp-best-practices/cppbestpractices/blob/master/05-Considering_Maintainability.md#properly-utilize-override-and-final)