### PR TITLE
Resolve IntelliSense errors

### DIFF
--- a/src/ftxui_sample/main.cpp
+++ b/src/ftxui_sample/main.cpp
@@ -2,15 +2,13 @@
 #include <optional>
 
 #ifdef __INTELLISENSE__
-#pragma diag_suppress 20
-#pragma diag_suppress 59
+#pragma diag_suppress 20, 59
 #endif
 #include <functional>
 #include <iostream>
 #include <random>
 #ifdef __INTELLISENSE__
-#pragma diag_default 20
-#pragma diag_default 59
+#pragma diag_default 20, 59
 #endif
 
 #include <CLI/CLI.hpp>

--- a/src/ftxui_sample/main.cpp
+++ b/src/ftxui_sample/main.cpp
@@ -1,9 +1,17 @@
 #include <array>
-#include <functional>
-#include <iostream>
 #include <optional>
 
+#ifdef __INTELLISENSE__
+#pragma diag_suppress 20
+#pragma diag_suppress 59
+#endif
+#include <functional>
+#include <iostream>
 #include <random>
+#ifdef __INTELLISENSE__
+#pragma diag_default 20
+#pragma diag_default 59
+#endif
 
 #include <CLI/CLI.hpp>
 #include <ftxui/component/captured_mouse.hpp>// for ftxui


### PR DESCRIPTION
Wraps external headers with #pragma diag_suppress 20 and diag_suppress 59 to silence erroneous IntelliSense errors.

These changes in addition to a [proposed change to lefticus::tools](https://github.com/lefticus/tools/pull/8) should resolve the project's errant IntelliSense warnings.