### PR TITLE
disable _FORTIFY_SOURCE for debug builds

### DIFF
--- a/cmake/Hardening.cmake
+++ b/cmake/Hardening.cmake
@@ -17,7 +17,9 @@ macro(
     set(NEW_CXX_DEFINITIONS "${NEW_CXX_DEFINITIONS} -D_GLIBCXX_ASSERTIONS")
     message(STATUS "*** GLIBC++ Assertions (vector[], string[], ...) enabled")
 
-    set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3")
+    if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+      set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3")
+    endif()
     message(STATUS "*** g++/clang _FORTIFY_SOURCE=3 enabled")
 
     #    check_cxx_compiler_flag(-fpie PIE)


### PR DESCRIPTION
Enabling this macro in debug builds causes a warning which is then treated as an error failing the build:
/usr/include/features.h:414:4: warning: _FORTIFY_SOURCE requires compiling with optimization (-O) [-W#warnings]
  414 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)