### PR TITLE
fix: safely replace description placeholder in janitor run

### DIFF
--- a/.github/workflows/template-janitor.yml
+++ b/.github/workflows/template-janitor.yml
@@ -57,17 +57,43 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Export description to variable
+        # This is basically needed as we have to have the value in an env variable to further process it in a safe manner.
+        # Also we can inject a mock-string for testing if the project is still the template.
+        if: fromJson(steps.get_repo_meta.outputs.data).is_template == false
+        run: |
+          # description can contain characters that mess with the sed command, so store it in a variable first.
+          # The content of the description will be copied as-is by the action which makes it nearly impossible to "just" use it.
+          # But by storing it in a variable with a heredoc the sed command will accept quotes and single quotes without a problem.
+          # The heredoc delimiter is deliberately verbose and complex to reduce the likeliness someone accidentally puts it in their
+          # description.
+          echo NEW_DESCRIPTION="$(cat <<'do;not(include}this[in%the$description'
+          ${{ fromJson(steps.get_repo_meta.outputs.data).description }}
+          do;not(include}this[in%the$description
+          )" >> $GITHUB_ENV
+
       - name: Use testing variables if still a template
         if: fromJson(steps.get_repo_meta.outputs.data).is_template == true
         run: |
           # This name is unsafe because it is not a valid C++ identifier
           echo "NEW_PROJECT=my-unsafe.project" >> $GITHUB_ENV
+          # This name is unsafe as the sed command later uses surrounding quotes and the pipe symbol. The other characters are generally harmful too.
+          NEW_DESCRIPTION=$(cat <<'EOF'
+          Unsafe because of "quotes" and unbalanced "quotes ('Also' 'unbalanced single). The sed uses | and used to have /. Variable expansion might be bad $GITHUB_ENV as well. Also \ should stay.
+          EOF
+          )
+          echo NEW_DESCRIPTION="$NEW_DESCRIPTION" >> $GITHUB_ENV
 
       - name: Add safe replacement variable versions
         run: |
           # hyphens and dots in c++ identifiers are forbidden. Use underscores instead.
           NEW_SAFE_PROJECT=$(echo ${{ env.NEW_PROJECT }} | sed "s/-/_/g" | sed "s/\./_/g" )
-          echo "NEW_SAFE_PROJECT=$NEW_SAFE_PROJECT" >> $GITHUB_ENV 
+          echo "NEW_SAFE_PROJECT=$NEW_SAFE_PROJECT" >> $GITHUB_ENV
+          # The sed command uses the pipe as the delimiter so escape that to make it safe.
+          # Also as we would remove any literal \ we have to escape those aswell and that has to
+          # be done first as it would mess with the escape for the | otherwise.
+          NEW_SAFE_DESCRIPTION="$(echo "$NEW_DESCRIPTION" | sed 's/\\/\\\\/g' | sed 's/|/\\|/g' )"
+          echo "NEW_SAFE_DESCRIPTION=$NEW_SAFE_DESCRIPTION" >> $GITHUB_ENV
 
       # Rename all cpp_starter_project occurences to current repository and remove this workflow
       - name: Insert new org and project
@@ -81,7 +107,8 @@ jobs:
           # fill in placeholders of readme and move it into place
           sed -i "s/%%myorg%%/${{ env.NEW_ORG }}/g" ${{ env.TEMPLATES_PATH }}/README.md
           sed -i "s/%%myproject%%/${{ env.NEW_PROJECT }}/g" ${{ env.TEMPLATES_PATH }}/README.md
-          sed -i "s|%%description%%|${{ fromJson(steps.get_repo_meta.outputs.data).description }}|g" ${{ env.TEMPLATES_PATH }}/README.md
+          # Use the variable from the env directly as githubs expansion would break the sed command.
+          sed -i "s|%%description%%|$NEW_SAFE_DESCRIPTION|g" ${{ env.TEMPLATES_PATH }}/README.md
           mv include/myproject include/${{ env.NEW_SAFE_PROJECT }}
           cp ${{ env.TEMPLATES_PATH }}/README.md README.md
 


### PR DESCRIPTION
Before this commit a (single-)quote or the pipe symbol in the description would make the janitor fail to replace the description placeholder as those made the sed statement malformed.

A first fix is to store the value of the description in a variable and pass that to the sed statement. This eliminates the problems of quotes and variable expansion due to $ signs. The variable had to be passed as a real variable instead of using githubs variable replacement as with that the shell would still see the quotes and parse them.

The second thing to fix is to escape any occurences of the pipe symbol in the description as that is what the sed command uses as its delimiter. The escaping has to be done by adding a literal \ to the description so during the sed command the | will stay in place. While doing this it became clear that also the \ has to be escaped as it would otherwise vanish after the sed run. Thus this is done prior to escaping the pipe symbol in order to not also mess with the introduced \ in that command.

To verify it is working the test step gained a new variable that is injected if the it is no new repo. With this at least it is checked that the description can contain the special characters. One thing to note though is that setting the test variable and extracting the actual description need to look alike so we can be sure the actual retrieval will not fail.

fixes #114 