### PR TITLE
Update PreventInSourceBuilds.cmake to replace get_filename_component with file(REAL_PATH) for symlink resolution

### DIFF
--- a/cmake/PreventInSourceBuilds.cmake
+++ b/cmake/PreventInSourceBuilds.cmake
@@ -3,8 +3,8 @@
 #
 function(myproject_assure_out_of_source_builds)
   # make sure the user doesn't play dirty with symlinks
-  get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
-  get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+  file(REAL_PATH "${CMAKE_SOURCE_DIR}" srcdir)
+  file(REAL_PATH "${CMAKE_BINARY_DIR}" bindir)
 
   # disallow in-source builds
   if("${srcdir}" STREQUAL "${bindir}")


### PR DESCRIPTION
"file" command offers a more modern approach to resolving symlinks. Introduced in CMake ≥ 3.19