### PR TITLE
Fix the 'Use this template' functionality

### DIFF
--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -37,7 +37,7 @@ function(myproject_setup_dependencies)
   endif()
 
   if(NOT TARGET tools::tools)
-    cpmaddpackage("gh:lefticus/tools#update_build_system")
+    cpmaddpackage("gh:lefticus/tools#main")
   endif()
 
 endfunction()


### PR DESCRIPTION
The branch used in the `lefticus/tools` repo specified in the `Dependencies.cmake` file has been merged to `main`. This results in a checkout failure in the template janitor. As a result, the script fails and the template is not updated in the user repo.

Adjusting the branch in the dependencies seems to fix this issue.