### PR TITLE
[WIP] Issue #134 — ENABLE_DEVELOPER_MODE is still relevant?

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,51 +57,25 @@
             }
         },
         {
-            "name": "windows-msvc-debug-developer-mode",
-            "displayName": "msvc Debug (Developer Mode)",
+            "name": "windows-msvc-debug",
+            "displayName": "msvc Debug",
             "description": "Target Windows with the msvc compiler, debug build type",
             "inherits": "conf-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "Debug",
-                "ENABLE_DEVELOPER_MODE": "ON"
+                "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
-            "name": "windows-msvc-release-developer-mode",
-            "displayName": "msvc Release (Developer Mode)",
+            "name": "windows-msvc-release",
+            "displayName": "msvc Release",
             "description": "Target Windows with the msvc compiler, release build type",
             "inherits": "conf-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "ENABLE_DEVELOPER_MODE": "ON"
-            }
-        },
-        {
-            "name": "windows-msvc-debug-user-mode",
-            "displayName": "msvc Debug (User Mode)",
-            "description": "Target Windows with the msvc compiler, debug build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "Debug",
-                "ENABLE_DEVELOPER_MODE": "OFF"
-            }
-        },
-        {
-            "name": "windows-msvc-release-user-mode",
-            "displayName": "msvc Release (User Mode)",
-            "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "ENABLE_DEVELOPER_MODE": "OFF"
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
         },
         {
@@ -195,18 +169,18 @@
             }
         },
         {
-            "name": "test-windows-msvc-debug-developer-mode",
+            "name": "test-windows-msvc-debug",
             "displayName": "Strict",
             "description": "Enable output and stop on failure",
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-debug-developer-mode"
+            "configurePreset": "windows-msvc-debug"
         },
         {
-            "name": "test-windows-msvc-release-developer-mode",
+            "name": "test-windows-msvc-release",
             "displayName": "Strict",
             "description": "Enable output and stop on failure",
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-release-developer-mode"
+            "configurePreset": "windows-msvc-release"
         },
         {
             "name": "test-windows-clang-debug",

--- a/ProjectOptions.cmake
+++ b/ProjectOptions.cmake
@@ -59,14 +59,6 @@ macro(myproject_supports_sanitizers)
 endmacro()
 
 macro(myproject_setup_options)
-  if(DEFINED ENABLE_DEVELOPER_MODE)
-    message(FATAL_ERROR
-      "ENABLE_DEVELOPER_MODE is not a valid option. "
-      "This project does not use aminya/project_options. "
-      "Developer mode is enabled when PROJECT_IS_TOP_LEVEL is set "
-      "and myproject_PACKAGING_MAINTAINER_MODE is not set.")
-  endif()
-
   option(myproject_ENABLE_HARDENING "Enable hardening" ON)
   option(myproject_ENABLE_COVERAGE "Enable coverage reporting" OFF)
   cmake_dependent_option(

--- a/ProjectOptions.cmake
+++ b/ProjectOptions.cmake
@@ -59,6 +59,14 @@ macro(myproject_supports_sanitizers)
 endmacro()
 
 macro(myproject_setup_options)
+  if(DEFINED ENABLE_DEVELOPER_MODE)
+    message(FATAL_ERROR
+      "ENABLE_DEVELOPER_MODE is not a valid option. "
+      "This project does not use aminya/project_options. "
+      "Developer mode is enabled when PROJECT_IS_TOP_LEVEL is set "
+      "and myproject_PACKAGING_MAINTAINER_MODE is not set.")
+  endif()
+
   option(myproject_ENABLE_HARDENING "Enable hardening" ON)
   option(myproject_ENABLE_COVERAGE "Enable coverage reporting" OFF)
   cmake_dependent_option(

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This is a C++ Best Practices GitHub template for getting up and running with C++ quickly.
 
-By default (collectively known as `ENABLE_DEVELOPER_MODE`)
+By default (when building as the top-level project)
 
  * Address Sanitizer and Undefined Behavior Sanitizer enabled where possible
  * Warnings as errors


### PR DESCRIPTION
Automated attempt by @leftibot. Opening as **draft** — verification failed.

**Reason:** no test files were detected in the diff

### What changed

> Fix #134: Remove dead ENABLE_DEVELOPER_MODE variable
> ENABLE_DEVELOPER_MODE was set in CMakePresets.json but never read by any
> CMake file — a leftover from when the project consumed aminya/project_options.
> Removed it from all presets, consolidated the duplicate developer-mode/user-mode
> Windows MSVC presets into single debug/release presets, updated the README, and
> added a configuration-time guard that rejects the variable with a helpful message.
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 CMakePresets.json    | 46 ++++++++++------------------------------------
 ProjectOptions.cmake |  8 ++++++++
 README.md            |  2 +-
 3 files changed, 19 insertions(+), 37 deletions(-)
```

Will close #134 once finalized.

_Triggered by @lefticus._