### PR TITLE
feat(tooling): add JSON schema references to clang config files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://www.schemastore.org/clang-format-21.x.json
 AccessModifierOffset: -2
 AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/clang-tidy.json
 ---
 Checks: "*,
         -abseil-*,


### PR DESCRIPTION
Adds $schema links to existing .clang-tidy and .clang-format. Gives editors autocomplete and real-time validation without changing any linting or formatting behavior.