### PR TITLE
Fix #139: From-scratch clone/build fails on `src/ftxui_sample/CMakeFiles/intro.dir/main.cpp.obj`

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,8 +33,8 @@
                 "strategy": "external"
             },
             "cacheVariables": {
-                "ENABLE_CPPCHECK_DEFAULT": "FALSE",
-                "ENABLE_CLANG_TIDY_DEFAULT": "FALSE"
+                "myproject_ENABLE_CPPCHECK": "FALSE",
+                "myproject_ENABLE_CLANG_TIDY": "FALSE"
             }
         },
         {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,15 @@ endif()
 
 include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
 
+# Regression test for issue #139: ensure windows-clang preset actually disables
+# cppcheck/clang-tidy by setting the real project option names.
+add_test(
+  NAME presets.windows_disables_static_analysis
+  COMMAND
+    ${CMAKE_COMMAND}
+    -DPRESETS_FILE=${CMAKE_SOURCE_DIR}/CMakePresets.json
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/test_cmake_presets.cmake)
+
 # Provide a simple smoke test to make sure that the CLI works and can display a --help message
 add_test(NAME cli.has_help COMMAND intro --help)
 

--- a/test/test_cmake_presets.cmake
+++ b/test/test_cmake_presets.cmake
@@ -1,0 +1,49 @@
+# Regression test for issue #139.
+#
+# CMakePresets.json must disable cppcheck and clang-tidy on the windows-clang
+# preset using the project's actual option names, otherwise from-scratch builds
+# fail when WARNINGS_AS_ERRORS is on and cppcheck flags third-party headers.
+
+if(NOT DEFINED PRESETS_FILE)
+  message(FATAL_ERROR "PRESETS_FILE not defined")
+endif()
+
+file(READ "${PRESETS_FILE}" PRESETS_JSON)
+
+string(JSON CONFIGURE_PRESETS_LEN LENGTH "${PRESETS_JSON}" "configurePresets")
+math(EXPR LAST_PRESET_IDX "${CONFIGURE_PRESETS_LEN} - 1")
+
+set(WINDOWS_PRESET_INDEX -1)
+foreach(I RANGE 0 ${LAST_PRESET_IDX})
+  string(JSON NAME GET "${PRESETS_JSON}" "configurePresets" ${I} "name")
+  if(NAME STREQUAL "conf-windows-common")
+    set(WINDOWS_PRESET_INDEX ${I})
+    break()
+  endif()
+endforeach()
+
+if(WINDOWS_PRESET_INDEX EQUAL -1)
+  message(FATAL_ERROR "conf-windows-common preset not found in ${PRESETS_FILE}")
+endif()
+
+string(JSON CACHE_VARS GET "${PRESETS_JSON}"
+  "configurePresets" ${WINDOWS_PRESET_INDEX} "cacheVariables")
+
+function(_assert_disabled var_name)
+  string(JSON VAL ERROR_VARIABLE ERR GET "${CACHE_VARS}" "${var_name}")
+  if(ERR)
+    message(FATAL_ERROR
+      "conf-windows-common cacheVariables is missing ${var_name}; "
+      "expected it to disable the analyzer (issue #139). "
+      "JSON error: ${ERR}")
+  endif()
+  if(NOT (VAL STREQUAL "OFF" OR VAL STREQUAL "FALSE" OR VAL STREQUAL "0" OR VAL STREQUAL "NO"))
+    message(FATAL_ERROR
+      "conf-windows-common cacheVariables sets ${var_name}=${VAL}, expected OFF/FALSE")
+  endif()
+endfunction()
+
+_assert_disabled("myproject_ENABLE_CPPCHECK")
+_assert_disabled("myproject_ENABLE_CLANG_TIDY")
+
+message(STATUS "conf-windows-common correctly disables cppcheck and clang-tidy")


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #139: rename dead preset cache vars so windows-clang disables analyzers
> The conf-windows-common preset declared ENABLE_CPPCHECK_DEFAULT=FALSE and
> ENABLE_CLANG_TIDY_DEFAULT=FALSE in cacheVariables, intending to disable
> those analyzers for windows-clang and windows-msvc presets. Those names
> are not consumed anywhere; the actual options are myproject_ENABLE_CPPCHECK
> and myproject_ENABLE_CLANG_TIDY, so cppcheck ran on Windows with
> WARNINGS_AS_ERRORS=ON, errored on third-party headers in fmt/spdlog, and
> aborted the intro target build. Renaming the cache variables to the real
> option names makes the preset's intent take effect.
> Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

### Files
```
 CMakePresets.json             |  4 ++--
 test/CMakeLists.txt           |  9 ++++++++
 test/test_cmake_presets.cmake | 49 +++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 60 insertions(+), 2 deletions(-)
```

Closes #139

_Triggered by @lefticus._